### PR TITLE
Add AdcQuality and PixelBitDepth (ICATHALES-58)

### DIFF
--- a/include/PrincetonInterface.h
+++ b/include/PrincetonInterface.h
@@ -84,13 +84,19 @@ namespace lima
       void setSensorTemperatureSetpoint(float temp);
 
       // gain attribute
-      Interface::GainType Interface::getAdcAnalogGain() const;
+      Interface::GainType getAdcAnalogGain() const;
       //void setAdcAnalogGain(int gain);
       void setAdcAnalogGain(Interface::GainType gain);
 
       //adcRate attribute
       float getAdcSpeed();
       void setAdcSpeed(float adcSpeed);
+	  
+	  int getAdcQuality() const;
+	  void setAdcQuality(int quality);
+	  
+	  short getAdcPixelBitDepth() const;
+	  void setAdcPixelBitDepth(short pixelBitDepth);
 
     private:
       void _freePixelBuffer();

--- a/src/PrincetonInterface.cpp
+++ b/src/PrincetonInterface.cpp
@@ -487,3 +487,45 @@ void Interface::_freePixelBuffer()
 #endif
   m_pixel_stream = {NULL,0};
 }
+
+int Interface::getAdcQuality() const
+{
+  DEB_MEMBER_FUNCT();
+  piint quality;
+  CHECK_PICAM(Picam_GetParameterIntegerValue(m_cam,
+						   PicamParameter_AdcQuality,
+						   &quality));
+
+  return (int)quality;
+}
+
+void Interface::setAdcQuality(int quality)
+{
+  DEB_MEMBER_FUNCT();
+
+  CHECK_PICAM(Picam_SetParameterIntegerValue(m_cam,
+						   PicamParameter_AdcQuality,
+						   quality));
+}
+
+// PixelBit Detph
+short Interface::getAdcPixelBitDepth() const
+{
+  DEB_MEMBER_FUNCT();
+  piint pixelBitDepth;
+  CHECK_PICAM(Picam_GetParameterIntegerValue(m_cam,
+						   PicamParameter_PixelBitDepth,
+						   &pixelBitDepth));
+
+  return (short)pixelBitDepth;
+}
+
+void Interface::setAdcPixelBitDepth(short pixelBitDepth)
+{
+    DEB_MEMBER_FUNCT();
+
+  CHECK_PICAM(Picam_SetParameterIntegerValue(m_cam,
+						   PicamParameter_PixelBitDepth,
+						   pixelBitDepth));
+}
+	  


### PR DESCRIPTION
Implémenter les fonctionnalités/attributs du SDK suivantes :

AdcQuality 
PixelBit Depth 
 

Dans le device spécifique créer les propriétés pour pouvoir communiquer avec la caméra tel que : le serial number et les attributs mémorisés.